### PR TITLE
Shorten Log Player Names

### DIFF
--- a/src/LogEvent.cpp
+++ b/src/LogEvent.cpp
@@ -62,7 +62,7 @@ void LogEvent::bakeStr(int max_display_name_length)
 
 	output += " - ";
 	
-	output += player ? max_display_name_length != 0 ? player->name.substr(0, max_display_name_length) : player->name  : "Unknown Player";
+	output += player ? max_display_name_length != 0 ? ((std::string_view)player->name).substr(0, max_display_name_length) : player->name  : "Unknown Player";
 
 	output += " ";
 	output += mechanic->name;

--- a/src/LogEvent.cpp
+++ b/src/LogEvent.cpp
@@ -1,6 +1,4 @@
 #include "LogEvent.h"
-
-#include "Tracker.h"
 #include "imgui/imgui.h"
 
 LogEvent::LogEvent(Player* new_player, Mechanic* new_mechanic, uint64_t new_time, uint64_t new_time_absolute, int64_t new_value, const cbtevent* new_ev, int max_display_name_length)

--- a/src/LogEvent.cpp
+++ b/src/LogEvent.cpp
@@ -62,7 +62,7 @@ void LogEvent::bakeStr(int max_display_name_length)
 
 	output += " - ";
 	
-	output += player ? max_display_name_length != 0 ? ((std::string_view)player->name).substr(0, max_display_name_length) : player->name  : "Unknown Player";
+	output += player ? ((std::string_view)player->name).substr(0, max_display_name_length) : "Unknown Player";
 
 	output += " ";
 	output += mechanic->name;

--- a/src/LogEvent.cpp
+++ b/src/LogEvent.cpp
@@ -1,8 +1,9 @@
 #include "LogEvent.h"
 
+#include "Tracker.h"
 #include "imgui/imgui.h"
 
-LogEvent::LogEvent(Player* new_player, Mechanic* new_mechanic, uint64_t new_time, uint64_t new_time_absolute, int64_t new_value, const cbtevent* new_ev)
+LogEvent::LogEvent(Player* new_player, Mechanic* new_mechanic, uint64_t new_time, uint64_t new_time_absolute, int64_t new_value, const cbtevent* new_ev, int max_display_name_length)
 {
 	player = new_player;
 	mechanic = new_mechanic;
@@ -12,7 +13,7 @@ LogEvent::LogEvent(Player* new_player, Mechanic* new_mechanic, uint64_t new_time
 	
 	if (new_ev)ev = *new_ev;
 
-	bakeStr();
+	bakeStr(max_display_name_length);
 }
 
 void LogEvent::draw()
@@ -40,7 +41,7 @@ void LogEvent::drawTooltip()
 	ImGui::EndTooltip();
 }
 
-void LogEvent::bakeStr()
+void LogEvent::bakeStr(int max_display_name_length)
 {
 	if (isPlaceholder())
 	{
@@ -62,8 +63,8 @@ void LogEvent::bakeStr()
 	output += std::to_string(abs(time) % 60);
 
 	output += " - ";
-
-	output += player ? player->name : "Unknown Player";
+	
+	output += player ? max_display_name_length != 0 ? player->name.substr(0, max_display_name_length) : player->name  : "Unknown Player";
 
 	output += " ";
 	output += mechanic->name;

--- a/src/LogEvent.h
+++ b/src/LogEvent.h
@@ -15,11 +15,11 @@ public:
 	int64_t value = 1;
 	cbtevent ev;
 
-	LogEvent(Player* new_player, Mechanic* new_mechanic, uint64_t new_time, uint64_t new_time_absolute, int64_t new_value, const cbtevent* new_ev);
+	LogEvent(Player* new_player, Mechanic* new_mechanic, uint64_t new_time, uint64_t new_time_absolute, int64_t new_value, const cbtevent* new_ev, int max_display_name_length);
 
 	void draw();
 	void drawTooltip();
-	void bakeStr();
+	void bakeStr(int max_display_name_length);
 	bool isPlaceholder();
 	std::string getFilterText();
 };

--- a/src/Tracker.cpp
+++ b/src/Tracker.cpp
@@ -202,7 +202,7 @@ void Tracker::processCombatEnter(const cbtevent* ev, ag* new_agent)
 				&& (ev->time - log_events.back().time_absolute) < combat_api_delay)
 			{//if a mechanic happens when the fight starts, it's probably part of the new fight and not the old one
 				log_events.back().time = getElapsedTime(ev->time);
-				log_events.back().bakeStr();
+				log_events.back().bakeStr(max_display_name_length);
 			}
 
 			if (has_logged_mechanic)
@@ -212,11 +212,11 @@ void Tracker::processCombatEnter(const cbtevent* ev, ag* new_agent)
 				if (log_events.size() > 1
 					&& (ev->time - log_events.back().time_absolute) < combat_api_delay)
 				{//if a mechanic happens when the fight starts, ensure the separator is before the mechanic
-					log_events.insert(--log_events.end(), LogEvent(nullptr, nullptr, getElapsedTime(ev->time), ev->time, 1,nullptr));
+					log_events.insert(--log_events.end(), LogEvent(nullptr, nullptr, getElapsedTime(ev->time), ev->time, 1,nullptr, max_display_name_length));
 				}
 				else
 				{
-					log_events.push_back(LogEvent(nullptr, nullptr, getElapsedTime(ev->time), ev->time, 1,nullptr));//TODO: make function for pushing log events
+					log_events.push_back(LogEvent(nullptr, nullptr, getElapsedTime(ev->time), ev->time, 1,nullptr, max_display_name_length));//TODO: make function for pushing log events
 				}
 
 				if (log_events.size() > max_log_events)
@@ -276,7 +276,7 @@ void Tracker::processMechanic(const cbtevent* ev, PlayerEntry* new_player_src, P
 	}
 	std::lock_guard<std::mutex> lg2(log_events_mtx);
 		
-	log_events.push_back(LogEvent(relevant_entry->player, new_mechanic, getElapsedTime(ev->time), ev->time, value, ev));
+	log_events.push_back(LogEvent(relevant_entry->player, new_mechanic, getElapsedTime(ev->time), ev->time, value, ev, max_display_name_length));
 		
 	if (log_events.size() > max_log_events)
 	{

--- a/src/Tracker.h
+++ b/src/Tracker.h
@@ -25,6 +25,7 @@ public:
 	
 	std::list<LogEvent> log_events;
 	int max_log_events = 300;
+	int max_display_name_length = 100;
 	
 	bool show_only_self = false;
 	bool export_chart_on_close = true;

--- a/src/arcdps_mechanicslog.cpp
+++ b/src/arcdps_mechanicslog.cpp
@@ -449,7 +449,10 @@ void parseIni()
 
 	pszValue = mechanics_ini.GetValue("log", "max_mechanics", std::to_string(tracker.max_log_events).c_str());
 	tracker.max_log_events = std::stoi(pszValue);
-
+	
+	pszValue = mechanics_ini.GetValue("log", "max_display_name_length", std::to_string(tracker.max_display_name_length).c_str());
+	tracker.max_display_name_length = std::stoi(pszValue);
+	
 	pszValue = mechanics_ini.GetValue("chart", "export_on_close", "1");
 	tracker.export_chart_on_close = std::stoi(pszValue);
 
@@ -475,6 +478,7 @@ void writeIni()
 	
 	rc = mechanics_ini.SetValue("general", "self_only", std::to_string(tracker.show_only_self).c_str());
 	rc = mechanics_ini.SetValue("log", "max_mechanics", std::to_string(tracker.max_log_events).c_str());
+	rc = mechanics_ini.SetValue("log", "max_display_name_length", std::to_string(tracker.max_display_name_length).c_str());
 	rc = mechanics_ini.SetValue("chart", "export_on_close", std::to_string(tracker.export_chart_on_close).c_str());
 
 	for (auto current_mechanic = getMechanics().begin(); current_mechanic != getMechanics().end(); ++current_mechanic)

--- a/src/imgui_panels.cpp
+++ b/src/imgui_panels.cpp
@@ -287,6 +287,8 @@ void AppOptions::draw(Tracker* tracker)
 		ImGui::Checkbox("Only show mechanics for self", &tracker->show_only_self);
 
 		ImGui::InputInt("Max mechanics in log", &tracker->max_log_events, 25);
+		
+		ImGui::InputInt("Max display name length", &tracker->max_display_name_length, 1);
 
 		ImGui::Checkbox("Export chart to CSV when game is closed", &tracker->export_chart_on_close);
 


### PR DESCRIPTION
This adds an option in the menu to decide how long the player name should be for mechanic log. Mechanic Chart will still have full name.
Some player have really long name and it is affecting the readability of the log infight.